### PR TITLE
Prevent docker network's collision at parallel drone exec execution

### DIFF
--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -2,8 +2,10 @@ package exec
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log"
+	"math/rand"
 	"os"
 	"path"
 	"path/filepath"
@@ -275,10 +277,14 @@ var Command = cli.Command{
 			EnvVar: "DRONE_JOB_NUMBER",
 		},
 		cli.StringSliceFlag{
-			Name: "env, e",
+			Name:   "env, e",
 			EnvVar: "DRONE_ENV",
 		},
 	},
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
 }
 
 func exec(c *cli.Context) error {
@@ -364,7 +370,12 @@ func exec(c *cli.Context) error {
 			c.StringSlice("network")...,
 		),
 		compiler.WithPrefix(
-			c.String("prefix"),
+			fmt.Sprintf(
+				"%s_%d_%d",
+				c.String("prefix"),
+				os.Getpid(),
+				rand.Int(),
+			),
 		),
 		compiler.WithProxy(),
 		compiler.WithLocal(


### PR DESCRIPTION
By default executing multiple `drone exec` commands in parallel raises
docker network's collision because prefix is static.

```
$ drone exec --local & drone exec --local
[1] 42934
2018/06/06 01:58:12 Error response from daemon: network drone_default is ambiguous (4 matches found on name)
2018/06/06 01:58:12 Error response from daemon: Conflict. The container name "/drone_step_0" is already in use by container "464a29b0726d6ff1a352d81df9c837330501085be550bb16abac3d338dfad887". You have to remove (or rename) that container to be able to reuse that name.
[1]  + exit 1     drone exec --local
```

On the other hand, drone server can execute parallel builds
without docker network collisions
because random prefix is used.

https://github.com/drone/drone/blob/29785b86f6534ded974120de0fcf7c21397a9d0d/server/hook.go#L552

So I add the random string to prefix to prevent the collisions.