### PR TITLE
Implement snap packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 drone/drone
 release
 .env
+*.snap

--- a/snap/local/launchers/drone-launch
+++ b/snap/local/launchers/drone-launch
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# This is the maintainence launcher for the snap, make necessary runtime
+# environment changes to make the snap work here.  You may also insert
+# security confinement/deprecation/obsoletion notice of the snap here.
+
+set \
+    -o errexit \
+    -o errtrace \
+    -o nounset \
+    -o pipefail
+
+if ! snapctl is-connected docker; then
+    printf "Warning: You haven't connected the snap to the \`docker\` interface, the application may not be able to interact with the local Docker service.  Refer <https://forum.snapcraft.io/t/error-snap-core-has-no-docker-interface-slots/16322/2> for instructions.\\n\\n" 1>&2
+fi
+
+# Finally run the next part of the command chain
+exec "${@}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,125 @@
+%YAML 1.1
+---
+# Snapcraft Recipe for Drone CLI
+# ------------------------------
+# This file is in the YAML data serialization format:
+# http://yaml.org
+# For the spec. of writing this file refer the following documentation:
+# * The snapcraft format
+#   https://docs.snapcraft.io/the-snapcraft-format/8337
+# * Snap Documentation
+#   https://docs.snapcraft.io
+# * Topics under the doc category in the Snapcraft Forum
+#   https://forum.snapcraft.io/c/doc
+# For support refer to the snapcraft section in the Snapcraft Forum:
+# https://forum.snapcraft.io/c/snapcraft
+
+name: drone
+license: Apache-2.0
+title: Drone CLI
+summary: Command Line Tools for Drone CI
+description: |
+  Command line client for the Drone continuous integration server.
+
+adopt-info: main
+architectures:
+  #- build-on: i386
+  - build-on: amd64
+  - build-on: armhf
+  - build-on: arm64
+  #- build-on: ppc64el
+  #- build-on: s390x
+
+assumes:
+  - command-chain
+
+  # `snapctl is-connected _interface_name_` support
+  # https://forum.snapcraft.io/t/snapctl-is-connected-plug-slot/14144
+  - snapd2.43
+
+base: core18
+confinement: strict
+grade: stable
+
+parts:
+  main:
+    after:
+      - selective-checkout
+
+    source: .
+    source-depth: 30
+    override-pull: |
+      snapcraftctl pull
+
+      "$SNAPCRAFT_STAGE"/scriptlets/selective-checkout
+
+    build-packages:
+      - gcc
+    plugin: go
+    override-build: |
+      # NOTE:
+      # As currently the Go plugin doesn't support custom -ldflags, we
+      # implement it manually while closely following Snapcraft's behavior:
+      # https://github.com/snapcore/snapcraft/blob/38996d5/snapcraft/plugins/v1/go.py#L243
+      git_version="$(git describe --tags --always --dirty)"
+      app_version="${git_version#v}"
+
+      go build \
+        -ldflags "-linkmode=external -X main.version=${app_version}" \
+        -o "${SNAPCRAFT_PART_INSTALL}"/bin/drone \
+        ./drone
+
+  # Launcher programs to fix problems at runtime
+  launchers:
+    source: snap/local/launchers
+    plugin: dump
+    organize:
+      '*': bin/
+    stage:
+      - -bin/README.*
+
+  # Stage snap for fixing the glibc locales(and gnu gettext I18N support)
+  # https://forum.snapcraft.io/t/the-locales-launch-stage-snap/10296
+  locales-launch:
+    plugin: nil
+    stage-snaps:
+      - locales-launch
+    stage-packages:
+      - libc-bin
+      - locales
+    stage:
+      - bin/locales-launch
+      - etc/locale.alias
+      - usr/bin/localedef
+      - usr/share/doc/locales
+      - usr/share/i18n
+      - usr/share/locale
+
+  # Check out the tagged release revision if it isn't promoted to the stable channel
+  # https://forum.snapcraft.io/t/selective-checkout-check-out-the-tagged-release-revision-if-it-isnt-promoted-to-the-stable-channel/10617
+  selective-checkout:
+    plugin: nil
+    build-packages:
+      - git
+    stage-snaps:
+      - selective-checkout
+    prime:
+      - -*
+
+apps:
+  drone:
+    adapter: full
+    command: bin/drone
+    command-chain:
+      - bin/locales-launch
+      - bin/drone-launch
+
+plugs:
+  docker:
+
+  # Regular files access
+  home:
+  removable-media:
+
+  # Network access
+  network:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,23 +77,6 @@ parts:
     stage:
       - -bin/README.*
 
-  # Stage snap for fixing the glibc locales(and gnu gettext I18N support)
-  # https://forum.snapcraft.io/t/the-locales-launch-stage-snap/10296
-  locales-launch:
-    plugin: nil
-    stage-snaps:
-      - locales-launch
-    stage-packages:
-      - libc-bin
-      - locales
-    stage:
-      - bin/locales-launch
-      - etc/locale.alias
-      - usr/bin/localedef
-      - usr/share/doc/locales
-      - usr/share/i18n
-      - usr/share/locale
-
   # Check out the tagged release revision if it isn't promoted to the stable channel
   # https://forum.snapcraft.io/t/selective-checkout-check-out-the-tagged-release-revision-if-it-isnt-promoted-to-the-stable-channel/10617
   selective-checkout:
@@ -110,8 +93,10 @@ apps:
     adapter: full
     command: bin/drone
     command-chain:
-      - bin/locales-launch
       - bin/drone-launch
+    environment:
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
 
 plugs:
   docker:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,7 +47,6 @@ parts:
       - selective-checkout
 
     source: .
-    source-depth: 30
     override-pull: |
       snapcraftctl pull
 


### PR DESCRIPTION
This pull request implements the necessary changes to package drone-cli as a snap,
[Snaps are universal linux packages](https://snapcraft.io/).

This PR should supersede #122 in terms of completeness, credits goes to @mikeroyal who provides most if not all the details needs to be taken care of, though this PR includes the following notable changes:

* Changing the snap and command name from `drone-cli` to `drone` to match documented usage
* Using my [selective checkout](https://forum.snapcraft.io/t/selective-checkout-check-out-the-tagged-release-revision-if-it-isnt-promoted-to-the-stable-channel/10617) scriptlet to checkout and build latest tagged release if the `stable` channel yet have one
* (Hopefully) Fix version tagging:

    ```shell
    $ drone --version
    drone version 1.2.1-6-geef6428-dirty
   ```

* Using my [locales-launch](https://forum.snapcraft.io/t/the-locales-launch-stage-snap/10296) launcher script to fix locales at runtime
* Adding [an app-specific maintenance launcher](https://github.com/Lin-Buo-Ren/drone-cli/blob/8df18d3) to check confinement status and for future conveniences.

This snap has been successfully built on amd64, armhf, and arm64 architectures, and is runnable on an amd64 system.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>