### PR TITLE
Removed syscerts dependency

### DIFF
--- a/drone/internal/util.go
+++ b/drone/internal/util.go
@@ -2,11 +2,11 @@ package internal
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 	"strings"
 
-	"github.com/jackspirou/syscerts"
 	"github.com/urfave/cli"
 	"golang.org/x/net/proxy"
 	"golang.org/x/oauth2"
@@ -35,7 +35,10 @@ func NewClient(c *cli.Context) (drone.Client, error) {
 	}
 
 	// attempt to find system CA certs
-	certs := syscerts.SystemRootsPool()
+	certs, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
 	tlsConfig := &tls.Config{
 		RootCAs:            certs,
 		InsecureSkipVerify: skip,

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/drone/signal v1.0.0
 	github.com/fatih/color v1.9.0
 	github.com/google/go-jsonnet v0.16.0
-	github.com/jackspirou/syscerts v0.0.0-20160531025014-b68f5469dff1
 	github.com/joho/godotenv v1.3.0
 	github.com/mattn/go-colorable v0.1.4
 	github.com/mattn/go-isatty v0.0.11


### PR DESCRIPTION
`master` won't build on Apple Silicon due to a dependency on `jackspirou/syscerts`. According to the README of `jackspirou/syscerts`, the package exists due to `crypto/x509` not exposing `systemRootsPool()`. This is now exposed as `SystemCertPool()` (https://go-review.googlesource.com/c/go/+/21293/).

I've updated to remove this dependency in favour of `crypto/x509`. As a result, it now builds on Apple Silicon. I have performed minimal testing (`drone info` and `drone sign --save ...`) without error.