### PR TITLE
Add support for jpath in jsonnet

### DIFF
--- a/drone/jsonnet/jsonnet.go
+++ b/drone/jsonnet/jsonnet.go
@@ -15,7 +15,6 @@ import (
 	"github.com/google/go-jsonnet"
 	"github.com/urfave/cli"
 )
-
 // Command exports the jsonnet command.
 var Command = cli.Command{
 	Name:      "jsonnet",

--- a/drone/jsonnet/jsonnet.go
+++ b/drone/jsonnet/jsonnet.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/fatih/color"
@@ -56,11 +57,22 @@ var Command = cli.Command{
 			Name:  "extVar, V",
 			Usage: "Pass extVars to Jsonnet (can be specified multiple times)",
 		},
+		cli.StringSliceFlag{
+			Name:  "jpath, J",
+			Usage: "Specify an additional library search dir (right-most wins)",
+		},
 	},
 }
 
 func generate(c *cli.Context) error {
-	result, err := convert(c.String("source"), c.Bool("string"), c.Bool("format"), c.Bool("stream"), c.StringSlice("extVar"))
+	result, err := convert(
+		c.String("source"),
+		c.Bool("string"),
+		c.Bool("format"),
+		c.Bool("stream"),
+		c.StringSlice("extVar"),
+		c.StringSlice("jpath"),
+	)
 	if err != nil {
 		return err
 	}
@@ -75,7 +87,7 @@ func generate(c *cli.Context) error {
 	return ioutil.WriteFile(target, []byte(result), 0644)
 }
 
-func convert(source string, stringOutput bool, format bool, stream bool, vars []string) (string, error) {
+func convert(source string, stringOutput bool, format bool, stream bool, vars []string, jpath []string) (string, error) {
 	data, err := ioutil.ReadFile(source)
 	if err != nil {
 		return "", err
@@ -91,6 +103,12 @@ func convert(source string, stringOutput bool, format bool, stream bool, vars []
 
 	// register native functions
 	RegisterNativeFuncs(vm)
+
+	jsonnetPath := filepath.SplitList(os.Getenv("JSONNET_PATH"))
+	jsonnetPath = append(jsonnetPath, jpath...)
+	vm.Importer(&jsonnet.FileImporter{
+		JPaths: jsonnetPath,
+	})
 
 	// extVars
 	for _, v := range vars {

--- a/drone/jsonnet/jsonnet_test.go
+++ b/drone/jsonnet/jsonnet_test.go
@@ -14,12 +14,20 @@ func TestConvert(t *testing.T) {
 		jsonnetFile, yamlFile        string
 		stringOutput, format, stream bool
 		extVars                      []string
+		jpath                        []string
 	}{
 		{
 			name:        "Stream + Format",
 			jsonnetFile: "stream_format.jsonnet",
 			yamlFile:    "stream_format.yaml",
 			format:      true, stream: true,
+		},
+		{
+			name:        "Jsonnet Path",
+			jsonnetFile: "stream_format.jsonnet",
+			yamlFile:    "stream_format.yaml",
+			format:      true, stream: true,
+			jpath: []string{"/path/to/jsonnet/lib"},
 		},
 	}
 
@@ -29,7 +37,7 @@ func TestConvert(t *testing.T) {
 			expected, err := os.ReadFile(filepath.Join("./testdata", tc.yamlFile))
 			assert.NoError(t, err)
 
-			result, err := convert(filepath.Join("./testdata", tc.jsonnetFile), tc.stringOutput, tc.format, tc.stream, tc.extVars)
+			result, err := convert(filepath.Join("./testdata", tc.jsonnetFile), tc.stringOutput, tc.format, tc.stream, tc.extVars, tc.jpath)
 			assert.NoError(t, err)
 			assert.Equal(t, string(expected), result)
 		})


### PR DESCRIPTION
The `go-jsonnet` library supports the use of jsonnet paths through a `FileImporter` to allow additional library paths to be included during template rendering. This PR adds a `jpath` CLI flag and support for a JSONNET_PATH environment variable similar to the [jsonnet CLI](https://github.com/google/go-jsonnet/blob/master/cmd/jsonnet/cmd.go) tool.