### PR TITLE
Lint: Remove output from `lint.go`

### DIFF
--- a/drone/lint/lint.go
+++ b/drone/lint/lint.go
@@ -79,7 +79,6 @@ func lint(c *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("%v\n", iter)
 		}
 	}
 	// now we can check the pipeline dependencies


### PR DESCRIPTION
Currently, when using `drone-cli v1.6.1`, when running `drone lint`, we get every iteration line printed in the console.
This could either be a leftover or an intentional print. If it's intentional, then a `--debug` flag could be added there.

**Steps to reproduce**:
```
$ drone-v1.6.1 lint .drone.yml --trusted
2022/11/04 17:43:46 proto: duplicate proto type registered: PluginSpec
2022/11/04 17:43:46 proto: duplicate proto type registered: PluginPrivilege
&{ pipeline docker pr-verify-drone [] {false 0 3 false false} {0} map[type:some-node] {linux amd64  } {{[] []} {[] []} {[] []} {[] []} {[] []} {[] []} {[pull_request] []} {[] []} {[] []} {[scripts/drone/** .drone.yml .drone.star] []}} map[] [] [0xc000120380 0xc000121180 0xc000121500 0xc000121880] [0xc0000ad840] [dockerconfigjson] { }}
```