### PR TITLE
fix: use right parameter name for secrets-file

### DIFF
--- a/drone/exec/flags.go
+++ b/drone/exec/flags.go
@@ -85,7 +85,7 @@ func mapOldToExecCommand(input *cli.Context) *execCommand {
 		Networks:   input.StringSlice("network"),
 		Environ:    readParams(input.String("env-file")),
 		Volumes:    withVolumeSlice(input.StringSlice("volume")),
-		Secrets:    readParams(input.String("secrets")),
+		Secrets:    readParams(input.String("secret-file")),
 		Config:     input.String("registry"),
 		Privileged: input.StringSlice("privileged"),
 		Pretty:     input.BoolT("pretty"),


### PR DESCRIPTION
The latest drone cli was using the parameter name as `secrets` instead of `secret-file` that was causing the secrets not being loaded for commands like `drone exec --secret-file=foo`