### PR TITLE
use standard crypto/x509 to support custom CA Certificates

### DIFF
--- a/drone/internal/util.go
+++ b/drone/internal/util.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+    "crypto/x509"
 
-	"github.com/jackspirou/syscerts"
 	"github.com/urfave/cli"
 	"golang.org/x/net/proxy"
 	"golang.org/x/oauth2"
@@ -35,7 +35,10 @@ func NewClient(c *cli.Context) (drone.Client, error) {
 	}
 
 	// attempt to find system CA certs
-	certs := syscerts.SystemRootsPool()
+	certs,err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
 	tlsConfig := &tls.Config{
 		RootCAs:            certs,
 		InsecureSkipVerify: skip,

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-jsonnet v0.18.0
-	github.com/jackspirou/syscerts v0.0.0-20160531025014-b68f5469dff1
 	github.com/joho/godotenv v1.4.0
 	github.com/mattn/go-colorable v0.1.12
 	github.com/mattn/go-isatty v0.0.14

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,6 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/jackspirou/syscerts v0.0.0-20160531025014-b68f5469dff1 h1:9Xm8CKtMZIXgcopfdWk/qZ1rt0HjMgfMR9nxxSeK6vk=
-github.com/jackspirou/syscerts v0.0.0-20160531025014-b68f5469dff1/go.mod h1:zuHl3Hh+e9P6gmBPvcqR1HjkaWHC/csgyskg6IaFKFo=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
 github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=


### PR DESCRIPTION
I had the problem to use a custom ca-certificate not in the standard path, with most tools it is possible to just specify `SSL_CERT_FILE` or `SSL_CERT_DIR` to use a different ca certificate with drone-cli it wasn't.

I figured I could simply switch to the golang standard `crypto/x509`.