### PR TITLE
docker: set the platform

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,6 +25,7 @@ steps:
       from_secret: docker_password
     auto_tag: true
     auto_tag_suffix: linux-amd64
+    platform: linux/amd64
   when:
     event: [push, tag]
   depends_on:
@@ -41,6 +42,7 @@ steps:
     auto_tag: true
     auto_tag_suffix: alpine-amd64
     dockerfile: Dockerfile.alpine
+    platform: linux/amd64
   when:
     event: [push, tag]
   depends_on:
@@ -57,6 +59,7 @@ steps:
     auto_tag: true
     auto_tag_suffix: linux-arm
     dockerfile: Dockerfile.linux.arm
+    platform: linux/arm
   when:
     event: [push, tag]
   depends_on:
@@ -73,6 +76,7 @@ steps:
     auto_tag: true
     auto_tag_suffix: linux-arm64
     dockerfile: Dockerfile.linux.arm64
+    platform: linux/arm64
   when:
     event: [push, tag]
   depends_on:
@@ -89,6 +93,7 @@ steps:
     auto_tag: true
     auto_tag_suffix: linux-ppc64le
     dockerfile: Dockerfile.linux.ppc64le
+    platform: linux/ppc64le
   when:
     event: [push, tag]
   depends_on:


### PR DESCRIPTION
This is needed for multiarch images to get proper metadata

[On Docker Hub we currently have](https://hub.docker.com/r/drone/cli/tags):

![Screenshot from 2023-08-22 11-36-02](https://github.com/harness/drone-cli/assets/321014/5090ca6d-93e8-448a-8323-084e2bfd2e5d)

All images in the manifest as `linux/amd64`, indicating that the images contained within the manifest weren't created properly.

Also see e.g. [this one](https://hub.docker.com/layers/drone/cli/linux-arm64/images/sha256-95b31ce0489939371b6274f37dcdb1a2ab4560686c982fc1403caf542db0f581?context=explore):

![image](https://github.com/harness/drone-cli/assets/321014/341af4ad-ce2e-4c40-b159-dcefdecaed7f)

which also has the wrong arch.

Here we set the platform which might fix it - not sure, as CI doesn't run the builds for me so I can't see the resulting images.