### PR TITLE
Unify Dockerfiles and pull images from the right arch

### DIFF
--- a/.drone.sh
+++ b/.drone.sh
@@ -8,8 +8,8 @@ export CGO_ENABLED=0
 # compile for all architectures
 GOOS=linux   GOARCH=amd64   go build -ldflags "-X main.version=${DRONE_TAG##v}" -o release/linux/amd64/drone       ./drone
 GOOS=linux   GOARCH=arm64   go build -ldflags "-X main.version=${DRONE_TAG##v}" -o release/linux/arm64/drone       ./drone
-GOOS=linux   GOARCH=ppc64le go build -ldflags "-X main.version=${DRONE_TAG##v}" -o release/linux/ppc64le/drone       ./drone
-GOOS=linux   GOARCH=arm     go build -ldflags "-X main.version=${DRONE_TAG##v}" -o release/linux/arm/drone         ./drone
+GOOS=linux   GOARCH=ppc64le go build -ldflags "-X main.version=${DRONE_TAG##v}" -o release/linux/ppc64le/drone     ./drone
+GOOS=linux   GOARCH=arm     go build -ldflags "-X main.version=${DRONE_TAG##v}" -o release/linux/arm/v7/drone      ./drone
 GOOS=windows GOARCH=amd64   go build -ldflags "-X main.version=${DRONE_TAG##v}" -o release/windows/amd64/drone.exe ./drone
 GOOS=darwin  GOARCH=amd64   go build -ldflags "-X main.version=${DRONE_TAG##v}" -o release/darwin/amd64/drone      ./drone
 GOOS=darwin  GOARCH=arm64   go build -ldflags "-X main.version=${DRONE_TAG##v}" -o release/darwin/arm64/drone      ./drone
@@ -18,7 +18,7 @@ GOOS=darwin  GOARCH=arm64   go build -ldflags "-X main.version=${DRONE_TAG##v}" 
 tar -cvzf release/drone_linux_amd64.tar.gz   -C release/linux/amd64   drone
 tar -cvzf release/drone_linux_arm64.tar.gz   -C release/linux/arm64   drone
 tar -cvzf release/drone_linux_ppc64le.tar.gz -C release/linux/ppc64le drone
-tar -cvzf release/drone_linux_arm.tar.gz     -C release/linux/arm     drone
+tar -cvzf release/drone_linux_arm.tar.gz     -C release/linux/arm/v7  drone
 tar -cvzf release/drone_windows_amd64.tar.gz -C release/windows/amd64 drone.exe
 tar -cvzf release/drone_darwin_amd64.tar.gz  -C release/darwin/amd64  drone
 tar -cvzf release/drone_darwin_arm64.tar.gz  -C release/darwin/arm64  drone

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,6 +25,7 @@ steps:
       from_secret: docker_password
     auto_tag: true
     auto_tag_suffix: linux-amd64
+    platform: linux/amd64
   when:
     event: [push, tag]
   depends_on:
@@ -41,6 +42,7 @@ steps:
     auto_tag: true
     auto_tag_suffix: alpine-amd64
     dockerfile: Dockerfile.alpine
+    platform: linux/amd64
   when:
     event: [push, tag]
   depends_on:
@@ -57,6 +59,7 @@ steps:
     auto_tag: true
     auto_tag_suffix: linux-arm
     dockerfile: Dockerfile.linux.arm
+    platform: linux/arm
   when:
     event: [push, tag]
   depends_on:
@@ -73,6 +76,7 @@ steps:
     auto_tag: true
     auto_tag_suffix: linux-arm64
     dockerfile: Dockerfile.linux.arm64
+    platform: linux/arm64
   when:
     event: [push, tag]
   depends_on:
@@ -89,6 +93,7 @@ steps:
     auto_tag: true
     auto_tag_suffix: linux-ppc64le
     dockerfile: Dockerfile.linux.ppc64le
+    platform: linux/ppc64le
   when:
     event: [push, tag]
   depends_on:

--- a/.drone.yml
+++ b/.drone.yml
@@ -41,7 +41,6 @@ steps:
       from_secret: docker_password
     auto_tag: true
     auto_tag_suffix: alpine-amd64
-    dockerfile: Dockerfile.alpine
     platform: linux/amd64
   when:
     event: [push, tag]
@@ -58,7 +57,6 @@ steps:
       from_secret: docker_password
     auto_tag: true
     auto_tag_suffix: linux-arm
-    dockerfile: Dockerfile.linux.arm
     platform: linux/arm
   when:
     event: [push, tag]
@@ -75,7 +73,6 @@ steps:
       from_secret: docker_password
     auto_tag: true
     auto_tag_suffix: linux-arm64
-    dockerfile: Dockerfile.linux.arm64
     platform: linux/arm64
   when:
     event: [push, tag]
@@ -92,7 +89,6 @@ steps:
       from_secret: docker_password
     auto_tag: true
     auto_tag_suffix: linux-ppc64le
-    dockerfile: Dockerfile.linux.ppc64le
     platform: linux/ppc64le
   when:
     event: [push, tag]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
-FROM drone/ca-certs
+FROM --platform=$BUILDPLATFORM alpine:3.18 as alpine
 
-COPY release/linux/amd64/drone /bin/
+RUN apk add -U --no-cache ca-certificates
+
+FROM scratch
+
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+ARG TARGETPLATFORM
+
+COPY release/${TARGETPLATFORM}/drone /bin/
 
 ENTRYPOINT ["/bin/drone"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,7 +1,0 @@
-FROM alpine:3.7
-
-RUN apk add --no-cache ca-certificates
-
-COPY release/linux/amd64/drone /bin/
-
-ENTRYPOINT ["/bin/drone"]

--- a/Dockerfile.linux.arm
+++ b/Dockerfile.linux.arm
@@ -1,5 +1,0 @@
-FROM drone/ca-certs
-
-COPY release/linux/arm/drone /bin/
-
-ENTRYPOINT ["/bin/drone"]

--- a/Dockerfile.linux.arm64
+++ b/Dockerfile.linux.arm64
@@ -1,6 +1,0 @@
-FROM drone/ca-certs
-
-COPY release/linux/arm64/drone /bin/
-
-ENTRYPOINT ["/bin/drone"]
-

--- a/Dockerfile.linux.ppc64le
+++ b/Dockerfile.linux.ppc64le
@@ -1,6 +1,0 @@
-FROM drone/ca-certs
-
-COPY release/linux/ppc64le/drone /bin/
-
-ENTRYPOINT ["/bin/drone"]
-


### PR DESCRIPTION
Eliminate the single-arch and outdated `ca-certs` image, and do this ourselves. Pull from the build arch when we need to run `apk`, and copy from the target arch.

This removes any differences between the Dockerfiles, so unify those into one.

(Contains #238, will rebase if/when that gets merged.)