### PR TITLE
upgrade alpine base image versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM amd64/alpine:3.17 as alpine
+FROM amd64/alpine:3.20 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM amd64/alpine:3.17
+FROM amd64/alpine:3.20
 ENV GODEBUG netdns=go
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 

--- a/Dockerfile.linux.arm
+++ b/Dockerfile.linux.arm
@@ -1,8 +1,8 @@
-FROM arm32v7/alpine:3.12 as alpine
+FROM arm32v7/alpine:3.20 as alpine
 RUN apk add -U --no-cache ca-certificates
 
 
-FROM arm32v7/alpine:3.12
+FROM arm32v7/alpine:3.20
 
 ENV GODEBUG netdns=go
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/Dockerfile.linux.arm64
+++ b/Dockerfile.linux.arm64
@@ -1,8 +1,8 @@
-FROM arm64v8/alpine:3.12 as alpine
+FROM arm64v8/alpine:3.20 as alpine
 RUN apk add -U --no-cache ca-certificates
 
 
-FROM arm64v8/alpine:3.12
+FROM arm64v8/alpine:3.20
 
 ENV GODEBUG netdns=go
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/


### PR DESCRIPTION
### What?
Update Alpine linux to 3.20 

### Why?
Related to various bug fixes and security updates delivered with version 3.20.